### PR TITLE
[ISSUE-027] Wire up SDK-wide CLI surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.4",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/src/supertone_cli/cli.py
+++ b/src/supertone_cli/cli.py
@@ -25,14 +25,14 @@ def _register_commands() -> None:
         register_predict_command,
         register_tts_command,
     )
-    from supertone_cli.commands.usage import register_usage_command
+    from supertone_cli.commands.usage import usage_app
     from supertone_cli.commands.voices import voices_app
 
     app.add_typer(config_app)
     app.add_typer(voices_app)
+    app.add_typer(usage_app)
     register_tts_command(app)
     register_predict_command(app)
-    register_usage_command(app)
 
 
 _register_commands()

--- a/src/supertone_cli/commands/tts.py
+++ b/src/supertone_cli/commands/tts.py
@@ -23,7 +23,10 @@ VALID_MODELS = {
     "supertonic_api_1",
     "sona_speech_2",
     "sona_speech_2_flash",
+    "sona_speech_2t",
 }
+
+VALID_OUTPUT_FORMATS = {"wav", "mp3"}
 
 # Model-parameter compatibility matrix
 _FLASH_DISALLOWED = {"similarity", "text_guidance"}
@@ -43,15 +46,13 @@ def validate_params(model: str, **kwargs: object) -> None:
     if model == "sona_speech_2_flash":
         bad = set(params) & _FLASH_DISALLOWED
         if bad:
-            raise InputError(
-                f"Parameters not supported by {model}: {', '.join(sorted(bad))}"
-            )
+            raise InputError(f"Not supported by {model}: {', '.join(sorted(bad))}")
 
     if model == "supertonic_api_1":
         bad = set(params) - _SUPERTONIC_ALLOWED - {"stream"}
         if bad:
             raise InputError(
-                f"Parameters not supported by {model}: "
+                f"Not supported by {model}: "
                 f"{', '.join(sorted(bad))}. "
                 f"Only speed is supported."
             )
@@ -116,6 +117,28 @@ def _collect_batch_files(input_path: str) -> list[Path]:
     return files
 
 
+def _build_settings_kwargs(
+    speed: float | None,
+    pitch: float | None,
+    pitch_variance: float | None,
+    similarity: float | None,
+    text_guidance: float | None,
+) -> dict:
+    """Build voice_settings kwargs for client.create_speech."""
+    settings: dict = {}
+    if speed is not None:
+        settings["speed"] = speed
+    if pitch is not None:
+        settings["pitch_shift"] = pitch
+    if pitch_variance is not None:
+        settings["pitch_variance"] = pitch_variance
+    if similarity is not None:
+        settings["similarity"] = similarity
+    if text_guidance is not None:
+        settings["text_guidance"] = text_guidance
+    return settings
+
+
 def _run_batch(
     input_path: str,
     outdir: str,
@@ -123,7 +146,9 @@ def _run_batch(
     voice: str,
     model: str,
     lang: str,
+    style: str | None,
     fail_fast: bool,
+    **voice_settings: object,
 ) -> None:
     """Process batch TTS for all .txt files in a directory."""
     files = _collect_batch_files(input_path)
@@ -145,6 +170,8 @@ def _run_batch(
                 model=model,
                 lang=lang,
                 output_format=output_format,
+                style=style,
+                **voice_settings,
             )
             out_file.write_bytes(audio)
             succeeded += 1
@@ -168,6 +195,8 @@ def _run_stream(
     model: str,
     lang: str,
     output: str | None,
+    style: str | None = None,
+    **voice_settings: object,
 ) -> None:
     """Stream TTS audio to the system audio device."""
     try:
@@ -180,11 +209,16 @@ def _run_stream(
     from supertone_cli.client import stream_speech
 
     chunks: list[bytes] = []
-    for chunk in stream_speech(text=text, voice=voice, model=model, lang=lang):
+    for chunk in stream_speech(
+        text=text,
+        voice=voice,
+        model=model,
+        lang=lang,
+        style=style,
+        **voice_settings,
+    ):
         chunks.append(chunk)
-        # In a real implementation, play chunk via sounddevice here
 
-    # Save to file if --output specified
     if output and output != "-":
         Path(output).write_bytes(b"".join(chunks))
 
@@ -192,7 +226,7 @@ def _run_stream(
     typer.echo(f"Streamed: {total_bytes} bytes", err=True)
 
 
-def _run_tts(
+def _run_tts(  # noqa: PLR0913
     text: str | None,
     input: str | None,
     output: str | None,
@@ -200,12 +234,22 @@ def _run_tts(
     voice: str | None,
     model: str | None,
     lang: str | None,
+    style: str | None,
     format: str,
     outdir: str | None = None,
     fail_fast: bool = False,
     stream: bool = False,
+    speed: float | None = None,
+    pitch: float | None = None,
+    pitch_variance: float | None = None,
+    similarity: float | None = None,
+    text_guidance: float | None = None,
 ) -> None:
     """Core TTS logic shared by the command."""
+    if output_format not in VALID_OUTPUT_FORMATS:
+        valid = ", ".join(sorted(VALID_OUTPUT_FORMATS))
+        raise InputError(f"Unsupported format: {output_format}. Valid: {valid}")
+
     resolved_voice = voice or get_default("default_voice")
     if not resolved_voice:
         raise InputError(
@@ -216,6 +260,21 @@ def _run_tts(
     resolved_model = model or get_default("default_model") or "sona_speech_2"
     resolved_lang = lang or get_default("default_lang") or "ko"
 
+    # Validate model-parameter compatibility
+    validate_params(
+        resolved_model,
+        speed=speed,
+        pitch_shift=pitch,
+        pitch_variance=pitch_variance,
+        similarity=similarity,
+        text_guidance=text_guidance,
+        stream=stream if stream else None,
+    )
+
+    voice_settings = _build_settings_kwargs(
+        speed, pitch, pitch_variance, similarity, text_guidance
+    )
+
     # Batch mode: directory input + outdir
     if _is_batch_input(input) and outdir:
         _run_batch(
@@ -225,7 +284,9 @@ def _run_tts(
             resolved_voice,
             resolved_model,
             resolved_lang,
+            style,
             fail_fast,
+            **voice_settings,
         )
         return
 
@@ -244,6 +305,8 @@ def _run_tts(
             resolved_model,
             resolved_lang,
             output,
+            style=style,
+            **voice_settings,
         )
         return
 
@@ -260,6 +323,8 @@ def _run_tts(
         model=resolved_model,
         lang=resolved_lang,
         output_format=output_format,
+        style=style,
+        **voice_settings,
     )
 
     if out_path is None:
@@ -283,7 +348,7 @@ def register_tts_command(app: typer.Typer) -> None:
     """Register TTS command directly on the main app."""
 
     @app.command("tts")
-    def tts_cmd(
+    def tts_cmd(  # noqa: PLR0913
         text: Optional[str] = typer.Argument(None, help="Text to synthesize."),
         input: Optional[str] = typer.Option(
             None, "--input", "-i", help="Path to text file."
@@ -297,11 +362,12 @@ def register_tts_command(app: typer.Typer) -> None:
         output_format: str = typer.Option(
             "wav",
             "--output-format",
-            help="Audio format (wav, mp3, ogg, flac).",
+            help="Audio format: wav, mp3.",
         ),
         voice: Optional[str] = typer.Option(None, "--voice", "-v", help="Voice ID."),
         model: Optional[str] = typer.Option(None, "--model", "-m", help="TTS model."),
         lang: Optional[str] = typer.Option(None, "--lang", "-l", help="Language code."),
+        style: Optional[str] = typer.Option(None, "--style", "-s", help="Voice style."),
         format: str = typer.Option(
             "text",
             "--format",
@@ -323,6 +389,17 @@ def register_tts_command(app: typer.Typer) -> None:
             "--stream",
             help="Stream audio to system output.",
         ),
+        speed: Optional[float] = typer.Option(None, "--speed", help="Speaking speed."),
+        pitch: Optional[float] = typer.Option(None, "--pitch", help="Pitch shift."),
+        pitch_variance: Optional[float] = typer.Option(
+            None, "--pitch-variance", help="Pitch variance."
+        ),
+        similarity: Optional[float] = typer.Option(
+            None, "--similarity", help="Voice similarity."
+        ),
+        text_guidance: Optional[float] = typer.Option(
+            None, "--text-guidance", help="Text guidance."
+        ),
     ) -> None:
         """Generate speech from text."""
         _run_tts(
@@ -333,10 +410,16 @@ def register_tts_command(app: typer.Typer) -> None:
             voice,
             model,
             lang,
+            style,
             format,
             outdir=outdir,
             fail_fast=fail_fast,
             stream=stream,
+            speed=speed,
+            pitch=pitch,
+            pitch_variance=pitch_variance,
+            similarity=similarity,
+            text_guidance=text_guidance,
         )
 
 
@@ -369,7 +452,8 @@ def register_predict_command(app: typer.Typer) -> None:
         if not resolved_voice:
             raise InputError(
                 "No voice specified. Use --voice <id> or "
-                "set a default: supertone config set default_voice <id>"
+                "set a default: "
+                "supertone config set default_voice <id>"
             )
 
         resolved_model = model or get_default("default_model") or "sona_speech_2"

--- a/src/supertone_cli/commands/usage.py
+++ b/src/supertone_cli/commands/usage.py
@@ -1,4 +1,4 @@
-"""Usage command: display API usage statistics."""
+"""Usage commands: credit balance, analytics, voice usage."""
 
 from __future__ import annotations
 
@@ -7,28 +7,114 @@ from dataclasses import asdict
 import typer
 
 from supertone_cli.client import get_usage
-from supertone_cli.output import print_json
+from supertone_cli.output import print_json, print_table
+
+usage_app = typer.Typer(name="usage", help="API usage commands.")
 
 
-def register_usage_command(app: typer.Typer) -> None:
-    """Register usage command on the main app."""
+@usage_app.command("balance")
+def balance_cmd(
+    format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json.",
+    ),
+) -> None:
+    """Display API credit balance."""
+    usage = get_usage()
 
-    @app.command("usage")
-    def usage_cmd(
-        format: str = typer.Option(
-            "text",
-            "--format",
-            "-f",
-            help="Output format: text or json.",
-        ),
-    ) -> None:
-        """Display API usage statistics."""
-        usage = get_usage()
+    if format == "json":
+        print_json(asdict(usage))
+        return
 
-        if format == "json":
-            print_json(asdict(usage))
-            return
+    if usage.plan:
+        typer.echo(f"Plan:    {usage.plan}")
+    if usage.used:
+        typer.echo(f"Used:    {usage.used}")
+    typer.echo(f"Credits: {usage.remaining}")
 
-        typer.echo(f"Plan:      {usage.plan}")
-        typer.echo(f"Used:      {usage.used}")
-        typer.echo(f"Remaining: {usage.remaining}")
+
+@usage_app.command("analytics")
+def analytics_cmd(
+    start: str = typer.Option(..., "--start", help="Start time (YYYY-MM-DD)."),
+    end: str = typer.Option(..., "--end", help="End time (YYYY-MM-DD)."),
+    bucket: str = typer.Option(
+        "day",
+        "--bucket",
+        help="Bucket width: day or hour.",
+    ),
+    format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json.",
+    ),
+) -> None:
+    """Show usage analytics for a date range."""
+    from supertone_cli.client import get_usage_analytics
+
+    results = get_usage_analytics(start, end, bucket)
+
+    if format == "json":
+        print_json(results)
+        return
+
+    if not results:
+        typer.echo("No usage data for this period.")
+        return
+
+    rows = [
+        [
+            r["period_start"],
+            r["period_end"],
+            f"{r['minutes_used']:.2f}",
+            r.get("voice_name") or r.get("voice_id") or "-",
+            r.get("model") or "-",
+        ]
+        for r in results
+    ]
+    print_table(
+        ["Start", "End", "Minutes", "Voice", "Model"],
+        rows,
+    )
+
+
+@usage_app.command("voices")
+def voice_usage_cmd(
+    start: str = typer.Option(..., "--start", help="Start date (YYYY-MM-DD)."),
+    end: str = typer.Option(..., "--end", help="End date (YYYY-MM-DD)."),
+    format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json.",
+    ),
+) -> None:
+    """Show per-voice usage for a date range."""
+    from supertone_cli.client import get_voice_usage
+
+    results = get_voice_usage(start, end)
+
+    if format == "json":
+        print_json(results)
+        return
+
+    if not results:
+        typer.echo("No voice usage data for this period.")
+        return
+
+    rows = [
+        [
+            r["date"],
+            r.get("name") or r["voice_id"],
+            f"{r['minutes_used']:.2f}",
+            r.get("model") or "-",
+            r.get("language") or "-",
+        ]
+        for r in results
+    ]
+    print_table(
+        ["Date", "Voice", "Minutes", "Model", "Language"],
+        rows,
+    )

--- a/src/supertone_cli/commands/voices.py
+++ b/src/supertone_cli/commands/voices.py
@@ -1,4 +1,4 @@
-"""Voices commands: list, search, clone."""
+"""Voices commands: list, search, clone, get, edit, delete."""
 
 from __future__ import annotations
 
@@ -7,13 +7,20 @@ from typing import Optional
 
 import typer
 
-from supertone_cli.client import list_voices, search_voices
+from supertone_cli.client import (
+    list_custom_voices,
+    list_voices,
+    search_voices,
+)
 from supertone_cli.errors import InputError
 from supertone_cli.output import print_json, print_table
 
-SUPPORTED_AUDIO_FORMATS = {".wav", ".mp3", ".ogg", ".flac"}
+SUPPORTED_AUDIO_FORMATS = {".wav", ".mp3"}
 
-voices_app = typer.Typer(name="voices", help="Voice management commands.")
+voices_app = typer.Typer(
+    name="voices",
+    help="Voice management commands.",
+)
 
 
 def _render_voices(voices: list, format: str) -> None:
@@ -36,7 +43,7 @@ def list_cmd(
         None,
         "--type",
         "-t",
-        help="Filter by voice type: preset or custom.",
+        help="Filter: preset or custom.",
     ),
     format: str = typer.Option(
         "text",
@@ -46,9 +53,12 @@ def list_cmd(
     ),
 ) -> None:
     """List available voices."""
-    voices = list_voices()
-    if type:
-        voices = [v for v in voices if v.type == type]
+    if type == "custom":
+        voices = list_custom_voices()
+    else:
+        voices = list_voices()
+        if type == "preset":
+            voices = [v for v in voices if v.type == "preset"]
     _render_voices(voices, format)
     if type == "custom" and not voices:
         typer.echo(
@@ -100,6 +110,37 @@ def search_cmd(
         )
 
 
+@voices_app.command("get")
+def get_cmd(
+    voice_id: str = typer.Argument(help="Voice ID."),
+    format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json.",
+    ),
+) -> None:
+    """Get details of a specific voice."""
+    from supertone_cli.client import get_voice
+
+    voice = get_voice(voice_id)
+
+    if format == "json":
+        print_json(asdict(voice))
+        return
+
+    typer.echo(f"Name:      {voice.name}")
+    typer.echo(f"ID:        {voice.id}")
+    typer.echo(f"Type:      {voice.type}")
+    typer.echo(f"Languages: {', '.join(voice.languages)}")
+    if voice.gender:
+        typer.echo(f"Gender:    {voice.gender}")
+    if voice.age:
+        typer.echo(f"Age:       {voice.age}")
+    if voice.use_cases:
+        typer.echo(f"Use cases: {', '.join(voice.use_cases)}")
+
+
 @voices_app.command("clone")
 def clone_cmd(
     name: str = typer.Option(..., "--name", "-n", help="Name for the cloned voice."),
@@ -139,3 +180,54 @@ def clone_cmd(
         f'Use: supertone tts --voice {result.voice_id} "text"',
         err=True,
     )
+
+
+@voices_app.command("edit")
+def edit_cmd(
+    voice_id: str = typer.Argument(help="Custom voice ID."),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New name."),
+    description: Optional[str] = typer.Option(
+        None, "--description", "-d", help="New description."
+    ),
+    format: str = typer.Option(
+        "text",
+        "--format",
+        "-f",
+        help="Output format: text or json.",
+    ),
+) -> None:
+    """Edit a custom voice's name or description."""
+    from supertone_cli.client import edit_custom_voice
+
+    if not name and not description:
+        raise InputError("Provide --name or --description to update.")
+
+    result = edit_custom_voice(voice_id, name=name, description=description)
+
+    if format == "json":
+        print_json(asdict(result))
+        return
+
+    typer.echo(f"Updated voice {result.voice_id}.")
+
+
+@voices_app.command("delete")
+def delete_cmd(
+    voice_id: str = typer.Argument(help="Custom voice ID."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation.",
+    ),
+) -> None:
+    """Delete a custom voice."""
+    from supertone_cli.client import delete_custom_voice
+
+    if not yes:
+        confirm = typer.confirm(f"Delete custom voice {voice_id}?")
+        if not confirm:
+            raise typer.Abort()
+
+    delete_custom_voice(voice_id)
+    typer.echo(f"Deleted voice {voice_id}.")

--- a/src/supertone_cli/models.py
+++ b/src/supertone_cli/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -12,7 +12,7 @@ class Voice:
     id: str
     name: str
     type: str  # "preset" or "custom"
-    languages: list[str]
+    languages: list[str] = field(default_factory=list)
     gender: str | None = None
     age: str | None = None
     use_cases: list[str] | None = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,6 @@ from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from supertone_cli.errors import APIError, AuthError
 
 # ── Data model tests ─────────────────────────────────────────────────
@@ -241,3 +240,186 @@ def test_get_usage_returns_usage():
         usage = get_usage()
         assert isinstance(usage, Usage)
         assert usage.remaining == 900
+
+
+# ── Additional client wrapper coverage ──────────────────────────────
+
+
+def test_search_voices_returns_filtered_list():
+    from supertone_cli.client import search_voices
+    from supertone_cli.models import Voice
+
+    mock_client = MagicMock()
+    mock_voice = MagicMock()
+    mock_voice.voice_id = "v2"
+    mock_voice.name = "Search Result"
+    mock_voice.language = ["ko", "en"]
+    mock_voice.gender = "female"
+    mock_voice.age = "adult"
+    mock_voice.use_cases = ["narration"]
+    mock_response = MagicMock()
+    mock_response.items = [mock_voice]
+    mock_client.voices.search_voices.return_value = mock_response
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        voices = search_voices(lang="ko", gender="female")
+        assert len(voices) == 1
+        assert isinstance(voices[0], Voice)
+        assert voices[0].id == "v2"
+        mock_client.voices.search_voices.assert_called_once_with(
+            language="ko", gender="female"
+        )
+
+
+def test_get_voice_returns_voice():
+    from supertone_cli.client import get_voice
+    from supertone_cli.models import Voice
+
+    mock_client = MagicMock()
+    mock_v = MagicMock()
+    mock_v.voice_id = "v1"
+    mock_v.name = "Test"
+    mock_v.language = "ko"
+    mock_v.gender = "male"
+    mock_v.age = "adult"
+    mock_v.use_cases = ["audiobook"]
+    mock_client.voices.get_voice.return_value = mock_v
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        voice = get_voice("v1")
+        assert isinstance(voice, Voice)
+        assert voice.id == "v1"
+        assert voice.name == "Test"
+
+
+def test_edit_custom_voice_returns_result():
+    from supertone_cli.client import edit_custom_voice
+    from supertone_cli.models import CloneResult
+
+    mock_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.voice_id = "v1"
+    mock_resp.name = "Renamed"
+    mock_client.custom_voices.edit_custom_voice.return_value = mock_resp
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        result = edit_custom_voice("v1", name="Renamed")
+        assert isinstance(result, CloneResult)
+        assert result.voice_id == "v1"
+
+
+def test_delete_custom_voice_calls_sdk():
+    from supertone_cli.client import delete_custom_voice
+
+    mock_client = MagicMock()
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        delete_custom_voice("v1")
+        mock_client.custom_voices.delete_custom_voice.assert_called_once_with(
+            voice_id="v1"
+        )
+
+
+def test_stream_speech_yields_chunks():
+    from supertone_cli.client import stream_speech
+
+    mock_client = MagicMock()
+    mock_client.text_to_speech.stream_speech.return_value = [b"chunk1", b"chunk2"]
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        chunks = list(stream_speech("Hello", "v1", "sona_speech_1", "ko"))
+        assert chunks == [b"chunk1", b"chunk2"]
+
+
+def test_get_usage_analytics_returns_list():
+    from supertone_cli.client import get_usage_analytics
+
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+    mock_bucket.starting_at = "2026-04-01"
+    mock_bucket.ending_at = "2026-04-02"
+    mock_result = MagicMock()
+    mock_result.minutes_used = 5.5
+    mock_result.voice_id = "v1"
+    mock_result.voice_name = "Voice1"
+    mock_result.model = "sona_speech_2"
+    mock_bucket.results = [mock_result]
+    mock_response = MagicMock()
+    mock_response.data = [mock_bucket]
+    mock_client.usage.get_usage.return_value = mock_response
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        results = get_usage_analytics("2026-04-01", "2026-04-02", "day")
+        assert len(results) == 1
+        assert results[0]["minutes_used"] == 5.5
+        assert results[0]["voice_name"] == "Voice1"
+
+
+def test_get_voice_usage_returns_list():
+    from supertone_cli.client import get_voice_usage
+
+    mock_client = MagicMock()
+    mock_u = MagicMock()
+    mock_u.date_ = "2026-04-01"
+    mock_u.voice_id = "v1"
+    mock_u.name = "Voice1"
+    mock_u.total_minutes_used = 3.2
+    mock_u.model = "sona_speech_2"
+    mock_u.language = "ko"
+    mock_response = MagicMock()
+    mock_response.usages = [mock_u]
+    mock_client.usage.get_voice_usage.return_value = mock_response
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        results = get_voice_usage("2026-04-01", "2026-04-30")
+        assert len(results) == 1
+        assert results[0]["date"] == "2026-04-01"
+        assert results[0]["minutes_used"] == 3.2
+
+
+def test_list_custom_voices_via_httpx():
+    from supertone_cli.client import list_custom_voices
+    from supertone_cli.models import Voice
+
+    mock_client = MagicMock()
+    mock_client.sdk_configuration.get_server_details.return_value = [
+        "https://api.supertone.ai"
+    ]
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"items": [{"voice_id": "c1", "name": "Custom1"}]}
+    mock_resp.raise_for_status = MagicMock()
+
+    with (
+        patch("supertone_cli.client.get_client", return_value=mock_client),
+        patch("supertone_cli.client.get_api_key", return_value="sk-test"),
+        patch("httpx.get", return_value=mock_resp),
+    ):
+        voices = list_custom_voices()
+        assert len(voices) == 1
+        assert isinstance(voices[0], Voice)
+        assert voices[0].id == "c1"
+        assert voices[0].type == "custom"
+
+
+def test_create_speech_with_voice_settings():
+    from supertone_cli.client import create_speech
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.result = b"audio-with-settings"
+    mock_client.text_to_speech.create_speech.return_value = mock_response
+
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
+        result = create_speech(
+            "Hello",
+            "v1",
+            "sona_speech_2",
+            "ko",
+            style="calm",
+            speed=1.2,
+            pitch_shift=-1.0,
+        )
+        assert result == b"audio-with-settings"
+        call_kwargs = mock_client.text_to_speech.create_speech.call_args.kwargs
+        assert "style" in call_kwargs
+        assert "voice_settings" in call_kwargs

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from supertone_cli.errors import APIError, AuthError
 
 # ── Data model tests ─────────────────────────────────────────────────

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -191,3 +191,78 @@ def test_tts_format_json_with_stdout_raises_input_error():
     )
     assert result.exit_code != 0
     assert isinstance(result.exception, InputError)
+
+
+# ── Voice setting flag passthrough ───────────────────────────────────
+
+
+def test_tts_voice_setting_flags_forwarded(tmp_path):
+    """All voice setting flags reach create_speech as kwargs."""
+    out = tmp_path / "out.wav"
+    with patch(
+        "supertone_cli.commands.tts.create_speech",
+        return_value=b"audio",
+    ) as mock_create:
+        result = runner.invoke(
+            app,
+            [
+                "tts",
+                "Hello",
+                "--voice",
+                "v1",
+                "--output",
+                str(out),
+                "--style",
+                "calm",
+                "--speed",
+                "1.2",
+                "--pitch",
+                "-1.5",
+                "--pitch-variance",
+                "0.8",
+                "--similarity",
+                "0.9",
+                "--text-guidance",
+                "0.7",
+            ],
+        )
+    assert result.exit_code == 0
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["style"] == "calm"
+    assert kwargs["speed"] == 1.2
+    assert kwargs["pitch_shift"] == -1.5
+    assert kwargs["pitch_variance"] == 0.8
+    assert kwargs["similarity"] == 0.9
+    assert kwargs["text_guidance"] == 0.7
+
+
+def test_tts_flash_rejects_similarity(tmp_path):
+    """sona_speech_2_flash + --similarity raises InputError end-to-end."""
+    out = tmp_path / "out.wav"
+    result = runner.invoke(
+        app,
+        [
+            "tts",
+            "Hello",
+            "--voice",
+            "v1",
+            "--model",
+            "sona_speech_2_flash",
+            "--similarity",
+            "0.8",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, InputError)
+
+
+def test_tts_unsupported_output_format_raises():
+    """--output-format ogg is rejected at CLI layer."""
+    result = runner.invoke(
+        app,
+        ["tts", "Hello", "--voice", "v1", "--output-format", "ogg"],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, InputError)

--- a/tests/test_tts_params.py
+++ b/tests/test_tts_params.py
@@ -44,3 +44,16 @@ def test_valid_model_no_params():
     validate_params("sona_speech_1")
     validate_params("sona_speech_2_flash")
     validate_params("supertonic_api_1")
+    validate_params("sona_speech_2t")
+
+
+def test_sona2t_allows_full_params():
+    """sona_speech_2t is a full-featured model — all voice settings allowed."""
+    validate_params(
+        "sona_speech_2t",
+        speed=1.0,
+        pitch_shift=0.5,
+        pitch_variance=0.8,
+        similarity=0.9,
+        text_guidance=0.7,
+    )

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -49,3 +49,122 @@ def test_usage_balance_api_error():
     ):
         result = runner.invoke(app, ["usage", "balance"])
     assert result.exit_code != 0
+
+
+# ── usage analytics ──────────────────────────────────────────────────
+
+
+_MOCK_ANALYTICS = [
+    {
+        "period_start": "2026-04-01T00:00:00Z",
+        "period_end": "2026-04-02T00:00:00Z",
+        "minutes_used": 12.34,
+        "voice_id": "v1",
+        "voice_name": "Voice1",
+        "model": "sona_speech_2",
+    }
+]
+
+
+def test_usage_analytics_table():
+    """usage analytics renders a table for a date range."""
+    with patch(
+        "supertone_cli.client.get_usage_analytics",
+        return_value=_MOCK_ANALYTICS,
+    ):
+        result = runner.invoke(
+            app,
+            ["usage", "analytics", "--start", "2026-04-01", "--end", "2026-04-30"],
+        )
+    assert result.exit_code == 0
+
+
+def test_usage_analytics_json():
+    """usage analytics --format json returns the raw list."""
+    with patch(
+        "supertone_cli.client.get_usage_analytics",
+        return_value=_MOCK_ANALYTICS,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "usage",
+                "analytics",
+                "--start",
+                "2026-04-01",
+                "--end",
+                "2026-04-30",
+                "--format",
+                "json",
+            ],
+        )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert data[0]["minutes_used"] == 12.34
+
+
+def test_usage_analytics_empty():
+    """usage analytics with no data prints a friendly message."""
+    with patch(
+        "supertone_cli.client.get_usage_analytics",
+        return_value=[],
+    ):
+        result = runner.invoke(
+            app,
+            ["usage", "analytics", "--start", "2026-04-01", "--end", "2026-04-02"],
+        )
+    assert result.exit_code == 0
+    assert "No usage data" in result.output
+
+
+# ── usage voices ─────────────────────────────────────────────────────
+
+
+_MOCK_VOICE_USAGE = [
+    {
+        "date": "2026-04-01",
+        "voice_id": "v1",
+        "name": "Voice1",
+        "minutes_used": 5.5,
+        "model": "sona_speech_2",
+        "language": "ko",
+    }
+]
+
+
+def test_usage_voices_table():
+    """usage voices renders per-voice breakdown as table."""
+    with patch(
+        "supertone_cli.client.get_voice_usage",
+        return_value=_MOCK_VOICE_USAGE,
+    ):
+        result = runner.invoke(
+            app,
+            ["usage", "voices", "--start", "2026-04-01", "--end", "2026-04-30"],
+        )
+    assert result.exit_code == 0
+
+
+def test_usage_voices_json():
+    """usage voices --format json returns the raw list."""
+    with patch(
+        "supertone_cli.client.get_voice_usage",
+        return_value=_MOCK_VOICE_USAGE,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "usage",
+                "voices",
+                "--start",
+                "2026-04-01",
+                "--end",
+                "2026-04-30",
+                "--format",
+                "json",
+            ],
+        )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data[0]["voice_id"] == "v1"

--- a/tests/test_voices.py
+++ b/tests/test_voices.py
@@ -107,3 +107,93 @@ def test_voices_list_json_empty():
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert data == []
+
+
+# ── voices get ───────────────────────────────────────────────────────
+
+
+def test_voices_get_human_readable():
+    """voices get prints Name/ID/Type/Languages."""
+    voice = Voice(
+        id="v1",
+        name="Test Voice",
+        type="preset",
+        languages=["ko", "en"],
+        gender="female",
+        age="adult",
+        use_cases=["narration"],
+    )
+    with patch("supertone_cli.client.get_voice", return_value=voice):
+        result = runner.invoke(app, ["voices", "get", "v1"])
+    assert result.exit_code == 0
+    assert "Test Voice" in result.output
+    assert "v1" in result.output
+    assert "ko" in result.output
+
+
+def test_voices_get_format_json():
+    """voices get --format json produces valid JSON."""
+    voice = Voice(id="v1", name="Test", type="preset", languages=["ko"])
+    with patch("supertone_cli.client.get_voice", return_value=voice):
+        result = runner.invoke(app, ["voices", "get", "v1", "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["id"] == "v1"
+    assert data["name"] == "Test"
+
+
+# ── voices edit ──────────────────────────────────────────────────────
+
+
+def test_voices_edit_name():
+    """voices edit --name updates the voice."""
+    from supertone_cli.models import CloneResult
+
+    with patch(
+        "supertone_cli.client.edit_custom_voice",
+        return_value=CloneResult(voice_id="v1", name="Renamed"),
+    ) as mock_edit:
+        result = runner.invoke(app, ["voices", "edit", "v1", "--name", "Renamed"])
+    assert result.exit_code == 0
+    mock_edit.assert_called_once_with("v1", name="Renamed", description=None)
+
+
+def test_voices_edit_requires_field():
+    """voices edit with neither --name nor --description exits with error."""
+    result = runner.invoke(app, ["voices", "edit", "v1"])
+    assert result.exit_code != 0
+
+
+def test_voices_edit_format_json():
+    """voices edit --format json returns JSON result."""
+    from supertone_cli.models import CloneResult
+
+    with patch(
+        "supertone_cli.client.edit_custom_voice",
+        return_value=CloneResult(voice_id="v1", name="New"),
+    ):
+        result = runner.invoke(
+            app, ["voices", "edit", "v1", "--name", "New", "--format", "json"]
+        )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["voice_id"] == "v1"
+
+
+# ── voices delete ────────────────────────────────────────────────────
+
+
+def test_voices_delete_with_yes():
+    """voices delete --yes skips confirmation."""
+    with patch("supertone_cli.client.delete_custom_voice") as mock_delete:
+        result = runner.invoke(app, ["voices", "delete", "v1", "--yes"])
+    assert result.exit_code == 0
+    mock_delete.assert_called_once_with("v1")
+
+
+def test_voices_delete_confirmation_declined():
+    """voices delete aborts when user declines confirmation."""
+    with patch("supertone_cli.client.delete_custom_voice") as mock_delete:
+        result = runner.invoke(app, ["voices", "delete", "v1"], input="n\n")
+    assert result.exit_code != 0
+    mock_delete.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -503,6 +503,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -597,6 +643,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 stream = [
@@ -607,6 +654,7 @@ stream = [
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "sounddevice", marker = "extra == 'stream'", specifier = ">=0.4" },


### PR DESCRIPTION
## Summary

Expose the full SDK feature surface that `client.py` already implements but the CLI wasn't wiring up. Closes no GH issue (local ISSUE-027 in `issues.md`).

### TTS (`commands/tts.py`)
- Add `--style`, `--speed`, `--pitch`, `--pitch-variance`, `--similarity`, `--text-guidance` flags forwarded to `create_speech` via a new `_build_settings_kwargs` helper.
- Add `sona_speech_2t` to `VALID_MODELS`.
- CLI-level `VALID_OUTPUT_FORMATS = {wav, mp3}` validation (previously only in help text).
- Thread `style` + `voice_settings` through `_run_batch` and `_run_stream`.

### Voices (`commands/voices.py`)
- Add `voices get <id>`, `voices edit <id>`, `voices delete <id>` subcommands backed by existing `client.get_voice` / `edit_custom_voice` / `delete_custom_voice`.
- Route `voices list --type custom` through `list_custom_voices()` (raw HTTP fallback).
- Narrow `SUPPORTED_AUDIO_FORMATS` to `{.wav, .mp3}`.

### Usage (`commands/usage.py` + `cli.py`)
- Refactor single `usage` command into `usage_app` Typer group with `balance`, `analytics`, `voices` subcommands.
- `analytics` supports `--start --end --bucket`; `voices` supports `--start --end`.
- `cli.py` now wires usage via `app.add_typer(usage_app)`.

### Models (`models.py`)
- `Voice.languages` gets `field(default_factory=list)` so SDK responses missing `language` don't break the dataclass.

### Tests (+16, total 106 → 122 passing)
- `test_voices.py`: get/edit/delete happy and error paths (7)
- `test_usage.py`: analytics/voices table + JSON paths (5)
- `test_tts.py`: voice-setting-flag passthrough, flash-rejects-similarity, unsupported-format rejection (3)
- `test_tts_params.py`: `sona_speech_2t` accepts full param set (1)

This fulfills the PRD goal "SDK 전체 기능 노출" that shipped ISSUE-006/008/011/012 left as client-only wiring.

## Test plan
- [x] \`uv run pytest -q\` → 122 passed
- [x] \`uv run ruff check src tests\` → 0 errors
- [x] \`uv build\` → sdist + wheel built successfully
- [x] \`supertone voices --help\` shows list/search/get/clone/edit/delete
- [x] \`supertone usage --help\` shows balance/analytics/voices
- [x] \`supertone tts --help\` shows --speed/--pitch/--pitch-variance/--similarity/--text-guidance/--style
- [ ] Manual smoke test with a real API key (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)