### PR TITLE
[ISSUE-021] Add CHANGELOG.md for 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-11
+
+### Added
+
+- `tts` command for single text-to-speech generation with voice, model, language, and output format options
+- `tts --batch` mode for processing multiple texts from a JSONL file
+- `tts-predict` command to estimate audio duration without generating speech
+- `tts --stream` flag for real-time streaming TTS playback via sounddevice
+- `voices list` subcommand to display all available preset and custom voices
+- `voices search` subcommand with filters for language, gender, age, and use case
+- `voices clone` subcommand to create a custom voice from an audio sample
+- `usage` command to check API credit balance and usage analytics
+- `config` command to manage API key and default settings via TOML config file
+- Rich-formatted table and JSON output modes (`--json` flag)
+- Unix pipe-friendly design: stdin input, stdout output, proper exit codes
+- Lazy imports for fast CLI startup (~50ms target)
+- CI pipeline with GitHub Actions (lint + test + coverage gate at 80%)
+
+[0.1.0]: https://github.com/pillip/supertone-cli/releases/tag/v0.1.0

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,15 +1,15 @@
-# Review Notes — ISSUE-026
+# Review Notes — ISSUE-021
 
 ## Code Review
 - **Verdict**: Approved
-- Both symlinks (ruff.toml, .prettierrc.json) correctly removed
-- extend-exclude list is comprehensive: .claude-kit, .claude, .venv, .worktrees, dist, build
-- pyproject.toml remains the single source of ruff configuration
-- ruff check exits 0 after changes
+- CHANGELOG.md follows Keep a Changelog 1.1.0 format correctly
+- All 5 CLI commands listed under Added section
+- pyproject.toml Changelog URL updated to point to CHANGELOG.md blob
+- Link reference at bottom uses correct format
 - No issues found
 
 ## Security Findings
-- None
+- None (documentation-only change)
 
 ## Follow-ups
 - None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 Homepage = "https://github.com/pillip/supertone-cli"
 Repository = "https://github.com/pillip/supertone-cli"
 Issues = "https://github.com/pillip/supertone-cli/issues"
-Changelog = "https://github.com/pillip/supertone-cli/releases"
+Changelog = "https://github.com/pillip/supertone-cli/blob/main/CHANGELOG.md"
 
 [project.scripts]
 supertone = "supertone_cli.cli:main"

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,33 @@
+"""Tests for CHANGELOG.md existence and format."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_changelog_exists():
+    """CHANGELOG.md exists at the repo root."""
+    assert (ROOT / "CHANGELOG.md").exists()
+
+
+def test_changelog_keepachangelog_format():
+    """CHANGELOG.md follows Keep a Changelog 1.1.0 format."""
+    content = (ROOT / "CHANGELOG.md").read_text()
+    assert "# Changelog" in content
+    assert "## [0.1.0]" in content
+    assert "### Added" in content
+
+
+def test_changelog_lists_all_commands():
+    """CHANGELOG.md lists every top-level CLI command under Added."""
+    content = (ROOT / "CHANGELOG.md").read_text()
+    for cmd in ("tts", "tts-predict", "voices", "usage", "config"):
+        assert cmd in content, f"Command '{cmd}' not found in CHANGELOG.md"
+
+
+def test_pyproject_has_changelog_url():
+    """pyproject.toml has a Changelog URL in [project.urls]."""
+    toml_content = (ROOT / "pyproject.toml").read_text()
+    assert "Changelog" in toml_content
+    # Should point to the CHANGELOG.md file, not just releases page
+    assert "CHANGELOG.md" in toml_content or "releases" in toml_content


### PR DESCRIPTION
Closes #37

## Summary
- Create `CHANGELOG.md` in Keep a Changelog 1.1.0 format documenting the 0.1.0 initial release
- Update `pyproject.toml` `[project.urls].Changelog` to point to `CHANGELOG.md`
- Add tests verifying file existence, format, command listing, and URL presence

## Test plan
- [x] `CHANGELOG.md` exists with `## [0.1.0]` section and `### Added` subsection
- [x] All CLI commands (`tts`, `tts-predict`, `voices`, `usage`, `config`) listed under Added
- [x] `pyproject.toml` has Changelog URL pointing to CHANGELOG.md
- [x] Full test suite passes (135 tests)