### PR TITLE
[ISSUE-026] Remove repo-root ruff.toml symlink, consolidate lint config in pyproject.toml

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,0 @@
-/Users/pillip/project/supertone-cli/.claude-kit/linters/.prettierrc.json

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,0 +1,15 @@
+# Review Notes — ISSUE-026
+
+## Code Review
+- **Verdict**: Approved
+- Both symlinks (ruff.toml, .prettierrc.json) correctly removed
+- extend-exclude list is comprehensive: .claude-kit, .claude, .venv, .worktrees, dist, build
+- pyproject.toml remains the single source of ruff configuration
+- ruff check exits 0 after changes
+- No issues found
+
+## Security Findings
+- None
+
+## Follow-ups
+- None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+extend-exclude = [".claude-kit", ".claude", ".venv", ".worktrees", "dist", "build"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,0 @@
-/Users/pillip/project/supertone-cli/.claude-kit/linters/ruff.toml

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -1,0 +1,43 @@
+"""Tests for lint configuration consolidation (ISSUE-026)."""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_no_ruff_toml_at_root():
+    """No ruff.toml file or symlink exists at the repo root."""
+    ruff_toml = ROOT / "ruff.toml"
+    assert not ruff_toml.exists() and not ruff_toml.is_symlink(), (
+        "ruff.toml should not exist at the repo root"
+    )
+
+
+def test_no_prettierrc_at_root():
+    """No .prettierrc.json symlink exists at the repo root."""
+    prettierrc = ROOT / ".prettierrc.json"
+    assert not prettierrc.exists() and not prettierrc.is_symlink(), (
+        ".prettierrc.json should not exist at the repo root"
+    )
+
+
+def test_pyproject_has_extend_exclude():
+    """pyproject.toml has extend-exclude with .claude-kit and .venv."""
+    content = (ROOT / "pyproject.toml").read_text()
+    assert "extend-exclude" in content
+    assert ".claude-kit" in content
+    assert ".venv" in content
+
+
+def test_ruff_check_exits_clean():
+    """uv run ruff check . exits 0 (no errors from .claude-kit or .venv)."""
+    result = subprocess.run(
+        ["uv", "run", "ruff", "check", "."],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, (
+        f"ruff check failed:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
Closes #42

## Summary
- Remove `ruff.toml` and `.prettierrc.json` symlinks at repo root (pointed to `.claude-kit/linters/`)
- Add `extend-exclude` to `[tool.ruff]` in `pyproject.toml` to exclude `.claude-kit`, `.venv`, `.worktrees`, etc.
- `uv run ruff check .` now exits clean (0 errors) using only `pyproject.toml` config

## Test plan
- [x] No `ruff.toml` or `.prettierrc.json` at repo root
- [x] `pyproject.toml` has `extend-exclude` with `.claude-kit` and `.venv`
- [x] `uv run ruff check .` exits 0
- [x] Full test suite passes (135 tests)