### PR TITLE
[ISSUE-024] Track upstream SDK fix for list_custom_voices raw HTTP fallback

### DIFF
--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,12 +1,11 @@
-# Review Notes — ISSUE-021
+# Review Notes — ISSUE-024
 
 ## Code Review
 - **Verdict**: Approved
-- CHANGELOG.md follows Keep a Changelog 1.1.0 format correctly
-- All 5 CLI commands listed under Added section
-- pyproject.toml Changelog URL updated to point to CHANGELOG.md blob
-- Link reference at bottom uses correct format
-- No issues found
+- WORKAROUND(ISSUE-024) comment block correctly placed above list_custom_voices
+- docs/upstream_bugs.md contains minimal repro, SDK version, and resolution plan
+- No runtime behavior changes (documentation only)
+- Tests verify marker existence and doc content
 
 ## Security Findings
 - None (documentation-only change)

--- a/docs/upstream_bugs.md
+++ b/docs/upstream_bugs.md
@@ -1,0 +1,47 @@
+# Upstream SDK Bugs
+
+Tracking known bugs in the `supertone` SDK that require workarounds in `supertone-cli`.
+
+---
+
+## list_custom_voices Pydantic ValidationError
+
+- **SDK Version**: supertone==0.2.0
+- **Observed**: 2026-04-03
+- **Status**: Open (workaround in place)
+- **Tracker**: ISSUE-024
+
+### Description
+
+The SDK's `custom_voices.list_custom_voices()` method fails with a Pydantic `ValidationError` because the response model requires a `description` field that the live API (`GET /v1/custom-voices`) does not return.
+
+### Minimal Repro
+
+```python
+from supertone import Supertone
+
+client = Supertone(api_key="<valid_key>")
+# This raises pydantic.ValidationError:
+# "1 validation error for CustomVoice
+#  description
+#    field required (type=value_error.missing)"
+voices = client.custom_voices.list_custom_voices()
+```
+
+### Workaround
+
+`supertone-cli` bypasses the SDK and calls the REST API directly via `httpx`:
+
+```python
+import httpx
+resp = httpx.get(
+    f"{base_url}/v1/custom-voices",
+    headers={"x-sup-api-key": api_key},
+)
+```
+
+See `src/supertone_cli/client.py:list_custom_voices()` — marked with `WORKAROUND(ISSUE-024)`.
+
+### Resolution
+
+Remove the workaround when the upstream SDK ships a fix (expected in supertone > 0.2.x). The fix should either make the `description` field optional in the Pydantic model or ensure the API always returns it.

--- a/src/supertone_cli/client.py
+++ b/src/supertone_cli/client.py
@@ -30,9 +30,7 @@ _client: Any = None
 def _is_auth_error(exc: Exception) -> bool:
     """Heuristic: detect authentication errors from SDK exceptions."""
     msg = str(exc).lower()
-    return any(
-        kw in msg for kw in ("auth", "unauthorized", "forbidden", "invalid key", "401")
-    )
+    return any(kw in msg for kw in ("auth", "unauthorized", "forbidden", "invalid key", "401"))
 
 
 def get_client() -> Any:
@@ -43,9 +41,7 @@ def get_client() -> Any:
 
     key = get_api_key()
     if not key:
-        raise AuthError(
-            "API key not configured. Run: supertone config set api_key <key>"
-        )
+        raise AuthError("API key not configured. Run: supertone config set api_key <key>")
 
     # Lazy import — SDK loaded only when needed (startup perf).
     from supertone import Supertone
@@ -80,9 +76,7 @@ def _get_model_enum(model: str) -> Any:
     if model not in mapping:
         from supertone_cli.errors import InputError
 
-        raise InputError(
-            f"Unsupported model: {model}. Valid: {', '.join(sorted(mapping.keys()))}"
-        )
+        raise InputError(f"Unsupported model: {model}. Valid: {', '.join(sorted(mapping.keys()))}")
     return mapping[model]
 
 
@@ -96,9 +90,7 @@ def _get_format_enum(fmt: str) -> Any:
     if fmt not in mapping:
         from supertone_cli.errors import InputError
 
-        raise InputError(
-            f"Unsupported format: {fmt}. Valid: {', '.join(sorted(mapping.keys()))}"
-        )
+        raise InputError(f"Unsupported format: {fmt}. Valid: {', '.join(sorted(mapping.keys()))}")
     return mapping[fmt]
 
 
@@ -255,14 +247,10 @@ def list_voices() -> list[Voice]:
                     type="preset",
                     languages=v.language
                     if hasattr(v, "language") and isinstance(v.language, list)
-                    else (
-                        [v.language] if hasattr(v, "language") and v.language else []
-                    ),
+                    else ([v.language] if hasattr(v, "language") and v.language else []),
                     gender=v.gender if hasattr(v, "gender") else None,
                     age=v.age if hasattr(v, "age") else None,
-                    use_cases=v.use_cases
-                    if hasattr(v, "use_cases") and v.use_cases
-                    else [],
+                    use_cases=v.use_cases if hasattr(v, "use_cases") and v.use_cases else [],
                 )
             )
         return voices
@@ -274,6 +262,11 @@ def list_voices() -> list[Voice]:
         raise APIError(str(exc)) from exc
 
 
+# WORKAROUND(ISSUE-024): The supertone SDK (v0.2.0) Pydantic model for custom
+# voice responses requires a 'description' field that the live API does not
+# return, causing a ValidationError. We bypass the SDK and call the REST API
+# directly via httpx. This workaround should be removed when upstream ships a
+# fix (supertone > 0.2.x). See: docs/upstream_bugs.md
 def list_custom_voices() -> list[Voice]:
     """List custom (cloned) voices via raw HTTP.
 
@@ -337,14 +330,10 @@ def search_voices(**filters: Any) -> list[Voice]:
                     type="preset",
                     languages=v.language
                     if hasattr(v, "language") and isinstance(v.language, list)
-                    else (
-                        [v.language] if hasattr(v, "language") and v.language else []
-                    ),
+                    else ([v.language] if hasattr(v, "language") and v.language else []),
                     gender=v.gender if hasattr(v, "gender") else None,
                     age=v.age if hasattr(v, "age") else None,
-                    use_cases=v.use_cases
-                    if hasattr(v, "use_cases") and v.use_cases
-                    else [],
+                    use_cases=v.use_cases if hasattr(v, "use_cases") and v.use_cases else [],
                 )
             )
         return voices
@@ -489,16 +478,10 @@ def get_usage_analytics(
                         "period_start": bucket.starting_at
                         if hasattr(bucket, "starting_at")
                         else "",
-                        "period_end": bucket.ending_at
-                        if hasattr(bucket, "ending_at")
-                        else "",
-                        "minutes_used": r.minutes_used
-                        if hasattr(r, "minutes_used")
-                        else 0,
+                        "period_end": bucket.ending_at if hasattr(bucket, "ending_at") else "",
+                        "minutes_used": r.minutes_used if hasattr(r, "minutes_used") else 0,
                         "voice_id": r.voice_id if hasattr(r, "voice_id") else None,
-                        "voice_name": r.voice_name
-                        if hasattr(r, "voice_name")
-                        else None,
+                        "voice_name": r.voice_name if hasattr(r, "voice_name") else None,
                         "model": r.model if hasattr(r, "model") else None,
                     }
                 )
@@ -525,9 +508,7 @@ def get_voice_usage(start_date: str, end_date: str) -> list[dict]:
                 "date": u.date_ if hasattr(u, "date_") else "",
                 "voice_id": u.voice_id if hasattr(u, "voice_id") else "",
                 "name": u.name if hasattr(u, "name") else None,
-                "minutes_used": u.total_minutes_used
-                if hasattr(u, "total_minutes_used")
-                else 0,
+                "minutes_used": u.total_minutes_used if hasattr(u, "total_minutes_used") else 0,
                 "model": u.model if hasattr(u, "model") else None,
                 "language": u.language if hasattr(u, "language") else None,
             }

--- a/tests/test_upstream_bugs.py
+++ b/tests/test_upstream_bugs.py
@@ -1,0 +1,21 @@
+"""Tests for ISSUE-024 upstream bug tracking documentation."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_todo_marker_in_client():
+    """client.py has a TODO(ISSUE-024) marker near list_custom_voices."""
+    content = (ROOT / "src" / "supertone_cli" / "client.py").read_text()
+    assert "WORKAROUND(ISSUE-024)" in content or "TODO(ISSUE-024)" in content
+
+
+def test_upstream_bugs_doc_exists():
+    """docs/upstream_bugs.md exists with repro details."""
+    upstream = ROOT / "docs" / "upstream_bugs.md"
+    assert upstream.exists(), "docs/upstream_bugs.md should exist"
+    content = upstream.read_text()
+    assert "list_custom_voices" in content
+    assert "supertone" in content.lower()
+    assert "0.2" in content  # SDK version reference


### PR DESCRIPTION
Closes #40

## Summary
- Add `WORKAROUND(ISSUE-024)` comment block above `list_custom_voices` in `client.py`
- Create `docs/upstream_bugs.md` with minimal repro, SDK version, and resolution plan
- No runtime behavior changes -- documentation only

## Test plan
- [x] `TODO(ISSUE-024)` or `WORKAROUND(ISSUE-024)` marker exists in client.py
- [x] `docs/upstream_bugs.md` exists with repro details and SDK version reference
- [x] Full test suite passes (141 tests)