### PR TITLE
[ISSUE-028] Remove list_custom_voices httpx workaround once SDK makes description optional

### DIFF
--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,16 +1,38 @@
-# Review Notes — ISSUE-025
+# Review Notes — ISSUE-028
 
 ## Code Review
-- **Verdict**: Approved
-- Integration marker properly registered in pyproject.toml
-- test_smoke.py correctly gated with both pytest.mark.integration and pytest.mark.skipif
-- Read-only smoke test (voices list) -- no destructive API calls
-- CliRunner + JSON output parsing is correct
-- Meta-tests verify infrastructure setup
-- Integration test properly skipped in default runs (150 passed, 1 skipped)
+- **Verdict**: Approve with nits.
+- The diff cleanly removes the `WORKAROUND(ISSUE-024)` block in `src/supertone_cli/client.py:list_custom_voices` and restores the SDK call via `client.custom_voices.list_custom_voices()`, mapped through the existing `_attr` / `_build_voice` helpers — consistent with `list_voices` / `search_voices` / `get_voice`.
+- Exception mapping (`AuthError` / `APIError`) reuses the standard `try/except` chain. `pydantic.ValidationError` from a future SDK regression would be surfaced as `APIError` via the existing `Exception` fallback — acceptable.
+- `pyproject.toml` floor bumped to `supertone>=0.2.1,<0.3`. `uv.lock` regen drops transitive `numpy` / `sounddevice` (upstream dropped them). In scope.
+- Tests pass: 152 passed, 1 skipped (`integration` marker, requires API key). Ruff clean.
+
+### Behavior change worth noting
+- `voices list-custom --format json` may now include `languages`, `gender`, `age`, `use_cases` keys when the SDK returns them. The prior httpx path emitted only `id`, `name`, `type`. Additive; consistent with preset listings. Captured in `CHANGELOG.md` `[Unreleased]`.
+
+### Cosmetic
+- Three unrelated line-wraps at `client.py:110-112`, `:147-149`, `:163-165` from the local 88-char `ruff.toml` symlink. Out-of-scope reformat; not a blocker (ruff is clean).
+- `test_list_custom_voices_does_not_use_httpx` (test_client.py) and `test_list_custom_voices_no_longer_uses_httpx` (test_upstream_bugs.py) overlap. Acceptable belt-and-suspenders for a one-time regression guard; consider deleting one after a release cycle.
 
 ## Security Findings
-- None. API key is read from environment, not hardcoded.
+- **None observed.** Removing the manual `x-sup-api-key` header injection slightly *reduces* surface — the SDK manages auth internally via `Supertone(api_key=...)`. No new sinks. Existing API-key sanitizer in the error layer continues to apply.
+- Dependency hygiene: `supertone==0.2.1` upgrade is upstream-driven and net-positive (smaller install footprint, fewer transitive CVE surfaces).
+
+## AC Coverage
+
+| AC | Evidence |
+|---|---|
+| `list_custom_voices` calls SDK; no httpx; no marker | `src/supertone_cli/client.py:323-335` |
+| Repo grep for `WORKAROUND(ISSUE-024)` / `TODO(ISSUE-024)` returns no production matches | grep clean (only inside intentional regression-guard test strings) |
+| `tests/test_upstream_bugs.py` no longer asserts marker / `0.2` | rewritten as regression guard |
+| `docs/upstream_bugs.md` entry marked Resolved with fixing version | `docs/upstream_bugs.md` Status line |
+| `pyproject.toml` pins fixed release | `pyproject.toml:35` |
+| `uv run pytest -q` passes | 152 passed, 1 skipped |
+| Manual smoke matches prior behavior | Owner-verified path; not run in this review |
+
+## Fixes Applied During Review
+- Added `[Unreleased]` section to `CHANGELOG.md` (managed on main via `flock_edit.sh`) capturing the SDK floor bump and the JSON output widening.
 
 ## Follow-ups
-- None
+- After 1–2 releases, drop one of the duplicate "no httpx in `list_custom_voices`" source-inspection tests.
+- Consider a project policy: cosmetic reformat-only hunks land in their own commit, not mixed with logic changes.

--- a/docs/upstream_bugs.md
+++ b/docs/upstream_bugs.md
@@ -8,8 +8,8 @@ Tracking known bugs in the `supertone` SDK that require workarounds in `superton
 
 - **SDK Version**: supertone==0.2.0
 - **Observed**: 2026-04-03
-- **Status**: Open (workaround in place)
-- **Tracker**: ISSUE-024
+- **Status**: Resolved in supertone==0.2.1 (2026-05-10) — workaround removed in ISSUE-028
+- **Tracker**: ISSUE-024 (resolved by ISSUE-028)
 
 ### Description
 
@@ -28,20 +28,10 @@ client = Supertone(api_key="<valid_key>")
 voices = client.custom_voices.list_custom_voices()
 ```
 
-### Workaround
+### Workaround (historical)
 
-`supertone-cli` bypasses the SDK and calls the REST API directly via `httpx`:
-
-```python
-import httpx
-resp = httpx.get(
-    f"{base_url}/v1/custom-voices",
-    headers={"x-sup-api-key": api_key},
-)
-```
-
-See `src/supertone_cli/client.py:list_custom_voices()` — marked with `WORKAROUND(ISSUE-024)`.
+`supertone-cli` previously bypassed the SDK and called the REST API directly via `httpx` in `src/supertone_cli/client.py:list_custom_voices()`. This was removed in ISSUE-028 once the upstream fix landed.
 
 ### Resolution
 
-Remove the workaround when the upstream SDK ships a fix (expected in supertone > 0.2.x). The fix should either make the `description` field optional in the Pydantic model or ensure the API always returns it.
+`supertone==0.2.1` ships a Pydantic model where `description` is `OptionalNullable[str] = UNSET` in `supertone/models/getcustomvoiceresponse.py`. ISSUE-028 reverted `list_custom_voices` to the SDK call and pinned `supertone>=0.2.1` in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "typer>=0.9,<1.0",
     "rich>=13.0",
     "tomli_w>=1.0",
-    "supertone>=0.2,<0.3",
+    "supertone>=0.2.1,<0.3",
 ]
 
 [project.optional-dependencies]

--- a/src/supertone_cli/client.py
+++ b/src/supertone_cli/client.py
@@ -107,7 +107,9 @@ def get_client() -> Any:
 
     key = get_api_key()
     if not key:
-        raise AuthError("API key not configured. Run: supertone config set api_key <key>")
+        raise AuthError(
+            "API key not configured. Run: supertone config set api_key <key>"
+        )
 
     # Lazy import -- SDK loaded only when needed (startup perf).
     from supertone import Supertone
@@ -142,7 +144,9 @@ def _get_model_enum(model: str) -> Any:
     if model not in mapping:
         from supertone_cli.errors import InputError
 
-        raise InputError(f"Unsupported model: {model}. Valid: {', '.join(sorted(mapping.keys()))}")
+        raise InputError(
+            f"Unsupported model: {model}. Valid: {', '.join(sorted(mapping.keys()))}"
+        )
     return mapping[model]
 
 
@@ -156,7 +160,9 @@ def _get_format_enum(fmt: str) -> Any:
     if fmt not in mapping:
         from supertone_cli.errors import InputError
 
-        raise InputError(f"Unsupported format: {fmt}. Valid: {', '.join(sorted(mapping.keys()))}")
+        raise InputError(
+            f"Unsupported format: {fmt}. Valid: {', '.join(sorted(mapping.keys()))}"
+        )
     return mapping[fmt]
 
 
@@ -314,38 +320,13 @@ def list_voices() -> list[Voice]:
         raise APIError(str(exc)) from exc
 
 
-# WORKAROUND(ISSUE-024): The supertone SDK (v0.2.0) Pydantic model for custom
-# voice responses requires a 'description' field that the live API does not
-# return, causing a ValidationError. We bypass the SDK and call the REST API
-# directly via httpx. This workaround should be removed when upstream ships a
-# fix (supertone > 0.2.x). See: docs/upstream_bugs.md
 def list_custom_voices() -> list[Voice]:
-    """List custom (cloned) voices via raw HTTP.
-
-    SDK has a validation bug (requires 'description' field
-    but API doesn't return it), so we use raw HTTP.
-    """
+    """List custom (cloned) voices."""
     client = get_client()
     try:
-        import httpx
-
-        base = client.sdk_configuration.get_server_details()[0]
-        key = get_api_key() or ""
-        resp = httpx.get(
-            f"{base}/v1/custom-voices",
-            headers={"x-sup-api-key": key},
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        items = data.get("items", [])
-        return [
-            Voice(
-                id=v.get("voice_id", ""),
-                name=v.get("name", ""),
-                type="custom",
-            )
-            for v in items
-        ]
+        response = client.custom_voices.list_custom_voices()
+        items = _attr(response, "items", [])
+        return [_build_voice(v, voice_type="custom") for v in items]
     except (AuthError, APIError):
         raise
     except Exception as exc:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -374,29 +374,38 @@ def test_get_voice_usage_returns_list():
         assert results[0]["minutes_used"] == 3.2
 
 
-def test_list_custom_voices_via_httpx():
+def test_list_custom_voices_via_sdk():
+    """list_custom_voices uses the SDK directly (no httpx workaround)."""
     from supertone_cli.client import list_custom_voices
     from supertone_cli.models import Voice
 
     mock_client = MagicMock()
-    mock_client.sdk_configuration.get_server_details.return_value = [
-        "https://api.supertone.ai"
-    ]
+    mock_voice = MagicMock(spec=["voice_id", "name"])
+    mock_voice.voice_id = "c1"
+    mock_voice.name = "Custom1"
+    mock_response = MagicMock()
+    mock_response.items = [mock_voice]
+    mock_client.custom_voices.list_custom_voices.return_value = mock_response
 
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"items": [{"voice_id": "c1", "name": "Custom1"}]}
-    mock_resp.raise_for_status = MagicMock()
-
-    with (
-        patch("supertone_cli.client.get_client", return_value=mock_client),
-        patch("supertone_cli.client.get_api_key", return_value="sk-test"),
-        patch("httpx.get", return_value=mock_resp),
-    ):
+    with patch("supertone_cli.client.get_client", return_value=mock_client):
         voices = list_custom_voices()
         assert len(voices) == 1
         assert isinstance(voices[0], Voice)
         assert voices[0].id == "c1"
+        assert voices[0].name == "Custom1"
         assert voices[0].type == "custom"
+        mock_client.custom_voices.list_custom_voices.assert_called_once()
+
+
+def test_list_custom_voices_does_not_use_httpx():
+    """Regression guard: list_custom_voices must not import or call httpx."""
+    import inspect
+
+    from supertone_cli.client import list_custom_voices
+
+    src = inspect.getsource(list_custom_voices)
+    assert "httpx" not in src, "list_custom_voices should no longer use httpx"
+    assert "WORKAROUND(ISSUE-024)" not in src
 
 
 def test_create_speech_with_voice_settings():

--- a/tests/test_upstream_bugs.py
+++ b/tests/test_upstream_bugs.py
@@ -1,21 +1,34 @@
-"""Tests for ISSUE-024 upstream bug tracking documentation."""
+"""Regression guard for ISSUE-024 / ISSUE-028 — workaround removed."""
 
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_todo_marker_in_client():
-    """client.py has a TODO(ISSUE-024) marker near list_custom_voices."""
+def test_workaround_marker_removed_from_client():
+    """No WORKAROUND(ISSUE-024) or TODO(ISSUE-024) markers remain in client.py."""
     content = (ROOT / "src" / "supertone_cli" / "client.py").read_text()
-    assert "WORKAROUND(ISSUE-024)" in content or "TODO(ISSUE-024)" in content
+    assert "WORKAROUND(ISSUE-024)" not in content
+    assert "TODO(ISSUE-024)" not in content
 
 
-def test_upstream_bugs_doc_exists():
-    """docs/upstream_bugs.md exists with repro details."""
+def test_list_custom_voices_no_longer_uses_httpx():
+    """list_custom_voices source must not import or call httpx."""
+    import inspect
+
+    from supertone_cli.client import list_custom_voices
+
+    src = inspect.getsource(list_custom_voices)
+    assert "httpx" not in src
+
+
+def test_upstream_bugs_doc_marks_resolved_or_removed():
+    """docs/upstream_bugs.md either omits the entry or marks it Resolved."""
     upstream = ROOT / "docs" / "upstream_bugs.md"
-    assert upstream.exists(), "docs/upstream_bugs.md should exist"
+    if not upstream.exists():
+        return
     content = upstream.read_text()
-    assert "list_custom_voices" in content
-    assert "supertone" in content.lower()
-    assert "0.2" in content  # SDK version reference
+    if "list_custom_voices" in content:
+        assert "Resolved" in content, (
+            "if list_custom_voices entry remains, it must be marked Resolved"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -281,67 +281,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
-    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
-    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
-    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
-    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
-    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
-    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
-    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -613,19 +552,17 @@ wheels = [
 
 [[package]]
 name = "supertone"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpcore" },
     { name = "httpx" },
-    { name = "numpy" },
     { name = "pydantic" },
     { name = "python-dotenv" },
-    { name = "sounddevice" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b5/91230745ea37e26f81b0f6641da22e494b51aea7c825286f9490a5465454/supertone-0.2.0.tar.gz", hash = "sha256:8130564121b6e767466bd4c6cd9e28120469eeb7dade015f1d74a24f79a4c847", size = 67097, upload-time = "2026-02-04T01:56:56.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/43/dab7839e9c554876221c4befdd138954da2346be0e867fb736a59c28319c/supertone-0.2.1.tar.gz", hash = "sha256:13c507c912493f68bc327285328851d96f7e33dfe9974c2394982e6de2bbabd4", size = 67461, upload-time = "2026-05-10T13:00:58.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/a2/70423d004bf2edd1911167ae733a94a30bf9d77427e67a8417a15923f7cd/supertone-0.2.0-py3-none-any.whl", hash = "sha256:3972a0603d19666480f2d4e378d081f3473c856fe95c976e8f1dc513125cb49b", size = 100816, upload-time = "2026-02-04T01:56:54.779Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/75/993496a0c0ef8b015767243981f4db9e0af8ad268bfcd3fe283024a55cb3/supertone-0.2.1-py3-none-any.whl", hash = "sha256:436585dc8f5458b5eae26067ad8aed54b8d718e5bd33edafb0b6980c870bd898", size = 102317, upload-time = "2026-05-10T13:00:57.144Z" },
 ]
 
 [[package]]
@@ -657,7 +594,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "sounddevice", marker = "extra == 'stream'", specifier = ">=0.4" },
-    { name = "supertone", specifier = ">=0.2,<0.3" },
+    { name = "supertone", specifier = ">=0.2.1,<0.3" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.9,<1.0" },
 ]


### PR DESCRIPTION
Closes #51

## Summary

Drops the raw `httpx` workaround introduced for ISSUE-024 now that the upstream `supertone` SDK has shipped a fix in v0.2.1.

- `client.list_custom_voices()` reverts to `client.custom_voices.list_custom_voices()` (SDK call), via existing `_attr` / `_build_voice` helpers.
- `WORKAROUND(ISSUE-024)` comment block removed; `httpx` no longer imported in this code path.
- `pyproject.toml`: `supertone>=0.2.1,<0.3` (was `>=0.2,<0.3`); `uv.lock` regenerated.
- `docs/upstream_bugs.md`: `list_custom_voices` entry marked **Resolved in supertone==0.2.1**.
- `tests/test_upstream_bugs.py`: rewritten as a regression guard — asserts the workaround marker is gone and `httpx` is not used in `list_custom_voices`.
- `tests/test_client.py`: `test_list_custom_voices_via_httpx` replaced with `test_list_custom_voices_via_sdk` (mocks SDK return) plus a `does_not_use_httpx` source-inspection test.

CLI user-facing surface unchanged — `supertone voices edit --description` was already optional, and the list-custom output shape is preserved (id/name/type, with extra fields populated where the SDK provides them).

Verified: `description: OptionalNullable[str] = UNSET` in `supertone==0.2.1`'s `getcustomvoiceresponse.py`.

## Test plan

- [x] `uv run pytest -q` — 152 passed, 1 skipped (integration).
- [x] `uv run ruff check .` — clean.
- [ ] Manual smoke against live API (`supertone voices list-custom`) — to be run by reviewer with valid `SUPERTONE_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
