### PR TITLE
[ISSUE-031] Fix --stream default model — auto-select sona_speech_1 when no -m given

### DIFF
--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -196,3 +196,43 @@ None. No Critical/High findings.
   `NotFoundErrorResponse` branch.
 - Make the custom-fallback tests use a realistic sparse response shape
   (voice_id/name/description only) and assert defaulted fields.
+
+## ISSUE-031 — --stream default model auto-select
+
+PR #60. Reviewed branch `issue/ISSUE-031-stream-default-model`.
+
+### Code Review
+- **Verdict**: Approve. No Critical/High findings.
+- The fix at `src/supertone_cli/commands/tts.py:265-268` is correct and minimal.
+  All four paths verified: stream+no-model → `sona_speech_1`; stream+explicit
+  incompatible → `validate_params` raises `InputError` (tts.py:60-61); stream+
+  explicit `sona_speech_1` → resolves correctly; non-streaming → unchanged.
+- Streaming returns early (tts.py:319) before batch/JSON branches, so no
+  interaction with those paths.
+- Security: no surface. Model is a hardcoded literal or validated against
+  `VALID_MODELS` before reaching the SDK. No secrets, injection, or auth change.
+
+### AC Coverage
+- AC #1 (auto-default): `test_stream_defaults_to_sona_speech_1`.
+- AC #2 (explicit compatible streams): `test_stream_calls_stream_speech`
+  (exit 0) + `test_stream_with_file_save`.
+- AC #3 (explicit incompatible errors): `test_stream_explicit_incompatible_model_still_errors`,
+  now also asserting the error message.
+- Config-default-bypass guarantee: `test_stream_default_overrides_config_default_model`
+  (added during review — the load-bearing path was previously untested, per RL-004).
+
+### Fixes Applied During Review
+- Added `test_stream_default_overrides_config_default_model` covering the
+  config `default_model` bypass (Low finding — the PR's core guarantee).
+- Hardened `test_stream_explicit_incompatible_model_still_errors` to assert the
+  `"Streaming requires sona_speech_1"` message, pinning the validate_params path.
+- Added `keep in sync with _STREAM_MODELS` note to the fix comment (Nit/RL-005):
+  the `"sona_speech_1"` literal duplicates the `_STREAM_MODELS` set (tts.py:36).
+
+### Tests / Lint
+- `pytest -q` (worktree): 166 passed.
+- `uv run ruff check .`: All checks passed.
+
+### Follow-ups (non-blocking)
+- If a second streaming model is ever added, derive the streaming default from
+  `_STREAM_MODELS` rather than the hardcoded literal (latent divergence, RL-005).

--- a/src/supertone_cli/commands/tts.py
+++ b/src/supertone_cli/commands/tts.py
@@ -258,10 +258,11 @@ def _run_tts(  # noqa: PLR0913
             "set a default: supertone config set default_voice <id>"
         )
 
-    # Streaming only supports sona_speech_1. When the user hasn't explicitly
-    # passed -m/--model, default the streaming path to sona_speech_1 so it works
-    # without an extra flag (config default_model is bypassed here for the same
-    # reason — any other default would always fail streaming).
+    # Streaming only supports sona_speech_1 (keep in sync with _STREAM_MODELS).
+    # When the user hasn't explicitly passed -m/--model, default the streaming
+    # path to sona_speech_1 so it works without an extra flag (config
+    # default_model is bypassed here for the same reason — any other default
+    # would always fail streaming).
     if stream and model is None:
         resolved_model = "sona_speech_1"
     else:

--- a/src/supertone_cli/commands/tts.py
+++ b/src/supertone_cli/commands/tts.py
@@ -54,7 +54,8 @@ def validate_params(model: str, **kwargs: object) -> None:
         bad = set(params) - _SUPERTONIC_ALLOWED - {"stream"}
         if bad:
             raise InputError(
-                f"Not supported by {model}: {', '.join(sorted(bad))}. Only speed is supported."
+                f"Not supported by {model}: {', '.join(sorted(bad))}. "
+                "Only speed is supported."
             )
 
     if params.get("stream") and model not in _STREAM_MODELS:
@@ -85,7 +86,8 @@ def _resolve_text(
 
     if not sources and not stdin_has_data:
         raise InputError(
-            "No input provided. Pass text as argument, use --input <file>, or pipe via stdin."
+            "No input provided. Pass text as argument, use --input <file>, "
+            "or pipe via stdin."
         )
 
     if text:
@@ -256,7 +258,14 @@ def _run_tts(  # noqa: PLR0913
             "set a default: supertone config set default_voice <id>"
         )
 
-    resolved_model = model or get_default("default_model") or "sona_speech_2"
+    # Streaming only supports sona_speech_1. When the user hasn't explicitly
+    # passed -m/--model, default the streaming path to sona_speech_1 so it works
+    # without an extra flag (config default_model is bypassed here for the same
+    # reason — any other default would always fail streaming).
+    if stream and model is None:
+        resolved_model = "sona_speech_1"
+    else:
+        resolved_model = model or get_default("default_model") or "sona_speech_2"
     resolved_lang = lang or get_default("default_lang") or "ko"
 
     # Validate model-parameter compatibility
@@ -270,7 +279,9 @@ def _run_tts(  # noqa: PLR0913
         stream=stream if stream else None,
     )
 
-    voice_settings = _build_settings_kwargs(speed, pitch, pitch_variance, similarity, text_guidance)
+    voice_settings = _build_settings_kwargs(
+        speed, pitch, pitch_variance, similarity, text_guidance
+    )
 
     # Batch mode: directory input + outdir
     if _is_batch_input(input) and outdir:
@@ -288,7 +299,9 @@ def _run_tts(  # noqa: PLR0913
         return
 
     if format == "json" and output == "-":
-        raise InputError("Cannot use --format json with --output -: both write to stdout.")
+        raise InputError(
+            "Cannot use --format json with --output -: both write to stdout."
+        )
 
     resolved_text = _resolve_text(text, input)
 
@@ -345,7 +358,9 @@ def register_tts_command(app: typer.Typer) -> None:
     @app.command("tts")
     def tts_cmd(  # noqa: PLR0913
         text: Optional[str] = typer.Argument(None, help="Text to synthesize."),
-        input: Optional[str] = typer.Option(None, "--input", "-i", help="Path to text file."),
+        input: Optional[str] = typer.Option(
+            None, "--input", "-i", help="Path to text file."
+        ),
         output: Optional[str] = typer.Option(
             None,
             "--output",
@@ -387,7 +402,9 @@ def register_tts_command(app: typer.Typer) -> None:
         pitch_variance: Optional[float] = typer.Option(
             None, "--pitch-variance", help="Pitch variance."
         ),
-        similarity: Optional[float] = typer.Option(None, "--similarity", help="Voice similarity."),
+        similarity: Optional[float] = typer.Option(
+            None, "--similarity", help="Voice similarity."
+        ),
         text_guidance: Optional[float] = typer.Option(
             None, "--text-guidance", help="Text guidance."
         ),
@@ -420,8 +437,12 @@ def register_predict_command(app: typer.Typer) -> None:
 
     @app.command("tts-predict")
     def predict_cmd(
-        text: Optional[str] = typer.Argument(None, help="Text to predict duration for."),
-        input: Optional[str] = typer.Option(None, "--input", "-i", help="Path to text file."),
+        text: Optional[str] = typer.Argument(
+            None, help="Text to predict duration for."
+        ),
+        input: Optional[str] = typer.Option(
+            None, "--input", "-i", help="Path to text file."
+        ),
         voice: Optional[str] = typer.Option(None, "--voice", "-v", help="Voice ID."),
         model: Optional[str] = typer.Option(None, "--model", "-m", help="TTS model."),
         lang: Optional[str] = typer.Option(None, "--lang", "-l", help="Language code."),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -56,6 +56,35 @@ def test_stream_missing_sounddevice():
     assert isinstance(result.exception, InputError)
 
 
+def test_stream_defaults_to_sona_speech_1():
+    """--stream without -m auto-selects sona_speech_1 (ISSUE-031)."""
+    mock_sd = MagicMock()
+    mock_stream = MagicMock(return_value=iter([b"chunk1"]))
+
+    with (
+        patch("supertone_cli.client.stream_speech", mock_stream),
+        patch.dict("sys.modules", {"sounddevice": mock_sd}),
+    ):
+        result = runner.invoke(
+            app,
+            ["tts", "Hello", "--voice", "v1", "--stream"],
+        )
+    assert result.exit_code == 0
+    assert mock_stream.call_args.kwargs["model"] == "sona_speech_1"
+
+
+def test_stream_explicit_incompatible_model_still_errors():
+    """Explicit -m with a non-streaming model is still rejected."""
+    mock_sd = MagicMock()
+    with patch.dict("sys.modules", {"sounddevice": mock_sd}):
+        result = runner.invoke(
+            app,
+            ["tts", "Hello", "--voice", "v1", "--stream", "--model", "sona_speech_2"],
+        )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, InputError)
+
+
 def test_stream_with_file_save(tmp_path):
     """--stream + --output saves to file too."""
     mock_chunks = [b"chunk1", b"chunk2"]

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -73,6 +73,28 @@ def test_stream_defaults_to_sona_speech_1():
     assert mock_stream.call_args.kwargs["model"] == "sona_speech_1"
 
 
+def test_stream_default_overrides_config_default_model():
+    """--stream without -m picks sona_speech_1 even when config default_model
+    is a non-streaming model (the load-bearing guarantee of ISSUE-031)."""
+    mock_sd = MagicMock()
+    mock_stream = MagicMock(return_value=iter([b"chunk1"]))
+
+    def fake_default(key):
+        return "sona_speech_2" if key == "default_model" else None
+
+    with (
+        patch("supertone_cli.client.stream_speech", mock_stream),
+        patch("supertone_cli.commands.tts.get_default", side_effect=fake_default),
+        patch.dict("sys.modules", {"sounddevice": mock_sd}),
+    ):
+        result = runner.invoke(
+            app,
+            ["tts", "Hello", "--voice", "v1", "--stream"],
+        )
+    assert result.exit_code == 0
+    assert mock_stream.call_args.kwargs["model"] == "sona_speech_1"
+
+
 def test_stream_explicit_incompatible_model_still_errors():
     """Explicit -m with a non-streaming model is still rejected."""
     mock_sd = MagicMock()
@@ -83,6 +105,7 @@ def test_stream_explicit_incompatible_model_still_errors():
         )
     assert result.exit_code != 0
     assert isinstance(result.exception, InputError)
+    assert "Streaming requires sona_speech_1" in str(result.exception)
 
 
 def test_stream_with_file_save(tmp_path):


### PR DESCRIPTION
Closes #59

## Problem
`supertone tts "hello" -v <voice-id> --stream` failed with `Error: Streaming requires sona_speech_1, but model is sona_speech_2.` because `_run_tts` resolved the model to the generic default (`sona_speech_2`) on the streaming path. Streaming is only supported on `sona_speech_1`, forcing users to pass `-m sona_speech_1` on every `--stream` call.

## Fix
In `src/supertone_cli/commands/tts.py:_run_tts`, when `--stream` is set and no explicit `-m/--model` is given, resolve the model to `sona_speech_1` — bypassing `config default_model` (which would otherwise always break streaming). An explicit incompatible model (e.g. `--stream -m sona_speech_2`) still errors as before.

## Behavior
- `tts "hi" -v <id> --stream` → works (auto `sona_speech_1`) ✅
- `tts "hi" -v <id> --stream -m sona_speech_1` → works ✅
- `tts "hi" -v <id> --stream -m sona_speech_2` → exit 3, incompatible-model error (unchanged) ✅

## Tests
- `test_stream_defaults_to_sona_speech_1` — asserts the resolved model
- `test_stream_explicit_incompatible_model_still_errors`
- Full unit suite: 165 passed; `ruff check .` clean.

## Follow-up (separate repo)
The API-docs `en|ko|ja/docs/sdks/cli.mdx` currently force `-m sona_speech_1` in every `--stream` example; those can drop the flag once this ships.